### PR TITLE
ci: migrate action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name:        'Get Changed Files'
 description: 'Saves lists of changed files as JSON for use by other actions.'
 author:      'Dustin Falgout <dustin@falgout.us>'
 runs:
-  using: 'node20'
+  using: 'node24'
   main:  'dist/index.js'
 inputs:
   token:


### PR DESCRIPTION
GitHub Actions runners have deprecated Node 20. Update runs.using so this action executes on Node 24.